### PR TITLE
docs: clarify Codex plugin auto-upgrade vs check_for_update_on_startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,11 @@ Both harnesses auto-update, differently. Claude Code's is **opt-in per marketpla
 by default for third-party), fetches ~10 min after session start, and updates marketplace
 metadata only — the installed plugin still needs `plugin update`. Codex's is **always on
 and undocumented**: a `plugins-marketplace-auto-upgrade` thread runs at app-server startup
-and force-reinstalls every git marketplace's plugins, gated only on `plugins_enabled`.
+(the TUI and `codex exec` embed the app-server, so those fire it too), checks each git
+marketplace's remote revision, and reinstalls the snapshot whenever it moved — gated only
+on `plugins_enabled`. `check_for_update_on_startup` does **not** affect it; that flag only
+governs Codex's own self-update prompt (and the desktop app ignores it even there,
+[codex#18543](https://github.com/openai/codex/issues/18543), closed as not planned).
 
 Manually: Claude Code needs two steps (`plugin marketplace update yorrick`, then
 `plugin update <name>@yorrick`); Codex does both with `codex plugin marketplace upgrade`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,8 +105,10 @@ codex plugin add <name>@yorrick
 ```
 
 Both harnesses auto-update, differently. Claude Code's is **opt-in per marketplace** (off
-by default for third-party), fetches ~10 min after session start, and updates marketplace
-metadata only — the installed plugin still needs `plugin update`. Codex's is **always on
+by default for third-party; Anthropic's own marketplaces default on), fires once per
+session at a random point within 10 min of startup, and updates both the marketplace
+metadata and the installed plugins on disk (version pins respected) — the running session
+keeps its loaded versions until `/reload-plugins` or restart. Codex's is **always on
 and undocumented**: a `plugins-marketplace-auto-upgrade` thread runs at app-server startup
 (the TUI and `codex exec` embed the app-server, so those fire it too), checks each git
 marketplace's remote revision, and reinstalls the snapshot whenever it moved — gated only

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Both harnesses auto-update — differently, and Codex's behaviour is undocumente
 
 | | Claude Code | Codex |
 |---|---|---|
-| Auto-update | **Opt-in per marketplace**, off by default for third-party | **Always on** while plugins are enabled; no dedicated opt-out |
-| Fires | ~10 min after session start | At app-server startup (TUI, `codex exec`, desktop app) |
-| Updates the installed plugin? | No — marketplace metadata only | **Yes** — reinstalls whenever the remote revision moved |
+| Auto-update | **Per-marketplace toggle** — off by default for third-party, on for Anthropic's own | **Always on** while plugins are enabled; no dedicated opt-out |
+| Fires | Once per session, at a random point within 10 min of start | At app-server startup (TUI, `codex exec`, desktop app) |
+| Updates the installed plugin? | **Yes**, where enabled — version pins respected | **Yes** — reinstalls whenever the remote revision moved |
 | Takes effect | After `/reload-plugins` or restart | Immediately; caches invalidated live |
 
 Enable it on Claude Code with `/plugin` → Marketplaces → `yorrick` → Enable auto-update.

--- a/README.md
+++ b/README.md
@@ -28,12 +28,17 @@ Both harnesses auto-update — differently, and Codex's behaviour is undocumente
 
 | | Claude Code | Codex |
 |---|---|---|
-| Auto-update | **Opt-in per marketplace**, off by default for third-party | **Always on**, no opt-out found |
-| Fires | ~10 min after session start | At app-server startup |
-| Updates the installed plugin? | No — marketplace metadata only | **Yes** — force-reinstalls |
+| Auto-update | **Opt-in per marketplace**, off by default for third-party | **Always on** while plugins are enabled; no dedicated opt-out |
+| Fires | ~10 min after session start | At app-server startup (TUI, `codex exec`, desktop app) |
+| Updates the installed plugin? | No — marketplace metadata only | **Yes** — reinstalls whenever the remote revision moved |
 | Takes effect | After `/reload-plugins` or restart | Immediately; caches invalidated live |
 
 Enable it on Claude Code with `/plugin` → Marketplaces → `yorrick` → Enable auto-update.
+
+Codex's `check_for_update_on_startup` config flag does **not** disable this — it only
+governs Codex's own self-update prompt (which the desktop app ignores anyway:
+[codex#18543](https://github.com/openai/codex/issues/18543), closed as not planned).
+The plugin auto-upgrade has no off switch short of `[features] plugins = false`.
 
 To update by hand:
 


### PR DESCRIPTION
Validates and corrects the Codex auto-update documentation, prompted by a claim that `check_for_update_on_startup` disables plugin update checks (citing codex#18543).

Verified against the openai/codex source (main) and local codex-cli 0.146.0:

- `check_for_update_on_startup` only gates Codex's **self-update prompt**; it is never referenced in the plugin/marketplace upgrade path. Issue [codex#18543](https://github.com/openai/codex/issues/18543) is about the desktop app ignoring it for app self-updates and was closed as not planned.
- The `plugins-marketplace-auto-upgrade` startup thread remains gated only on `plugins_enabled`; no dedicated opt-out exists.
- Refinements to our previous wording: the upgrade is revision-checked (git ls-remote; no-op when the remote has not moved) rather than a blind force-reinstall, and it fires from the TUI and `codex exec` too (in-process app-server), not just the desktop app.

Cross-AI reviewed via `codex exec` (read-only): no factual blockers; three low-severity wording nits, all applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CM3PfZnJ6wNjWJ5DJsEsdo